### PR TITLE
Fix firebase initialization error

### DIFF
--- a/src/features/hooks/useAuth/index.ts
+++ b/src/features/hooks/useAuth/index.ts
@@ -1,10 +1,15 @@
 import { useEffect, useState } from "react";
+import { getApps, initializeApp } from "firebase/app";
 import { User, getAuth, onAuthStateChanged } from "firebase/auth";
+import { firebaseConfig } from "@/utils/Firebase/firebaseConfig";
 
 const useAuth = () => {
   const [user, setUser] = useState<User | null>(null);
 
   useEffect(() => {
+    if (getApps().length) {
+      initializeApp(firebaseConfig);
+    }
     const auth = getAuth();
     const unsubscribe = onAuthStateChanged(auth, (user) => {
       if (user) {

--- a/src/utils/Firebase/firebaseConfig.ts
+++ b/src/utils/Firebase/firebaseConfig.ts
@@ -12,4 +12,4 @@ const firebaseConfig = {
 const firebaseApp = initializeApp(firebaseConfig);
 const auth = getAuth(firebaseApp);
 
-export { auth, firebaseApp };
+export { auth, firebaseApp, firebaseConfig };


### PR DESCRIPTION
This pull request fixes an error that occurs when attempting to retrieve a user without initializing the firebase instance. The issue is resolved by checking if the firebase instance has been created and initializing it if necessary.

No issue reference