### PR TITLE
Add API endpoint to get user by ID

### DIFF
--- a/src/pages/api/user/[uid].ts
+++ b/src/pages/api/user/[uid].ts
@@ -1,0 +1,24 @@
+import { prisma } from "@/utils/Prisma/PrismaClient";
+import { NextApiRequest, NextApiResponse } from "next";
+
+const getUserHandler = async (req: NextApiRequest, res: NextApiResponse) => {
+  const { uid } = req.query;
+
+  if (req.method === "GET") {
+    const user = await prisma.user.findUnique({
+      where: {
+        userId: uid as string,
+      },
+    });
+
+    if (!user) {
+      return res.status(404).json({ error: "User not found" });
+    }
+
+    return res.status(200).json(user);
+  }
+
+  return res.status(405).json({ error: "Method not allowed" });
+}
+
+export default getUserHandler;


### PR DESCRIPTION
This pull request adds a new API endpoint to retrieve user information by their ID. The endpoint accepts a GET request and returns the user object if found. If the user is not found, a 404 error is returned. The code implementation uses Prisma to query the database and returns the user object as a JSON response.

Fixes #1234